### PR TITLE
Systemd update

### DIFF
--- a/dist/systemd/horepgd.service
+++ b/dist/systemd/horepgd.service
@@ -1,13 +1,12 @@
 [Unit]
-Description=EPG update service
+Description=Horizon EPG update service for TVHeadend
 After=tvheadend.service
 Requires=tvheadend.service
  
 [Service]
-Type=simple
+Type=oneshot
 Nice=19
-ExecStart=/usr/local/bin/horepgd.py -u hts -g video -p /var/run/horepgd.pid
-PIDFile=/var/run/horepgd.pid
+ExecStart=/usr/bin/horepgd.py -u hts -g video -R -1
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/systemd/horepgd.timer
+++ b/dist/systemd/horepgd.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Update TVHeadend Horizon EPG once a day
+
+[Timer]
+OnCalendar=daily
+AccuracySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This PR updates the systemd horepgd.service to type oneshot (and thus uses the new '-1'-parameter), to be used by a systemd timer horepgd.timer. This enables the user to adapt the frequency with which the EPG update is executed.
So, by starting (or enabling) the horepgd.timer. the horepgd.service is called once a day by default (and only runs once).
Next to that, in horepgd.service, I enabled the EPG update for radio channels as well by default.