### PR TITLE
Fix HTTP error 500 causing script to crash

### DIFF
--- a/horepg/horizon.py
+++ b/horepg/horizon.py
@@ -25,6 +25,12 @@ class HorizonRequest(object):
     def request(self, method, path, retry=True):
         self.connection.request(method, path)
         response = self.connection.getresponse()
+        if response.status == 500:
+            debug('Failed to request data from Horizon API, HTTP status {:0}'.format(response.status))
+            debug('Waiting for 5 seconds before trying again !')
+            time.sleep(5)
+            self.connection = http.client.HTTPSConnection(HorizonRequest.hosts[self.current])
+            return self.request(method, path, retry=True)
         if response.status == 200:
             return response
         elif response.status == 403:


### PR DESCRIPTION
Sometimes the script would crash when receiving HTTP error 500 if the Horizon API was busy. I added a sleep option and a retry, as normally an error 500 is something which occurs every now and then. Output when error 500 is hit :

DEBUG:root:Adding 190 programmes for channel Aljazeera English
DEBUG:root:Adding 55 programmes for channel TV538
DEBUG:root:Adding 183 programmes for channel Travel Channel HD
**DEBUG:root:Adding 112 programmes for channel MyZen HD
DEBUG:root:Failed to request data from Horizon API, HTTP status 500
DEBUG:root:Waiting for 5 seconds before trying again !
DEBUG:root:Adding 127 programmes for channel SBS9 HD**
DEBUG:root:Adding 133 programmes for channel DJAZZ
DEBUG:root:Adding 118 programmes for channel BBC Two HD
