### PR TITLE
Improve EPG category mappings

### DIFF
--- a/horepg/tvheadend.py
+++ b/horepg/tvheadend.py
@@ -6,10 +6,14 @@ Fetch a list of channels from TVHeadend
 
 import requests
 import socket
+from requests.auth import HTTPDigestAuth
 
 def tvh_get_channels(host, port=9981, username='', password=''):
   channels = []
   r = requests.get('http://{:s}:{:d}/api/channel/list'.format(host, port), auth=(username, password))
+  if r.status_code == 401:
+    # Retry with HTTP digest authentication
+    r = requests.get('http://{:s}:{:d}/api/channel/list'.format(host, port), auth=HTTPDigestAuth(username, password))
   if r.status_code != 200:
     raise Exception('connection to tvheadend failed with status {:d}'.format(r.status_code))
   data = r.json()

--- a/horepg/xmltvdoc.py
+++ b/horepg/xmltvdoc.py
@@ -1,80 +1,109 @@
 import xml.dom.minidom
 import time
-import datetime
-import calendar
+import logging
+
+
+def debug(msg):
+  logging.debug(msg)
+
+
+def warning(msg):
+  logging.warning(msg)
+
 
 class XMLTVDocument(object):
   # this renames some of the channels
   add_display_name = {}
   category_map = {
-    'tv drama': 'movie/drama (general)',
-    'actie': 'movie/drama (general)',
-    'familie': 'movie/drama (general)',
+    # 01
+    'tv drama': 'movie/drama',
+    'actie': 'movie/drama',
+    'familie': 'movie/drama',
     'thriller': 'detective/thriller',
     'detective': 'detective/thriller',
-    'avontuur': 'detective/thriller',
-    'western': 'detective/thriller',
+    'avontuur': 'adventure/western/war',
+    'western': 'adventure/western/war',
     'horror': 'science fiction/fantasy/horror',
     'sci-fi': 'science fiction/fantasy/horror',
+    'sci-fi/horror': 'science fiction/fantasy/horror',
     'komedie': 'comedy',
-    'melodrama': 'science fiction/fantasy/horror',
+    'melodrama': 'soap/melodrama/folkloric',
     'romantiek': 'romance',
     'drama': 'serious/classical/religious/historical movie/drama',
     'erotiek': 'adult movie/drama',
-    'nieuws': 'news/current affairs (general)',
+
+    # 02
+    'nieuws': 'news/current affairs',
     'weer': 'news/weather report',
     'nieuws documentaire': 'news magazine',
     'documentaire': 'documentary',
     'historisch': 'documentary',
     'waar gebeurd': 'documentary',
     'discussie': 'discussion/interview/debate',
+
+    # 03
     'show': 'game show/quiz/contest',
     'variété': 'variety show',
+    'variete': 'variety show',
     'talkshow': 'talk show',
-    'sport': 'sports (general)',
-    'gevechtssport': 'martial sports',
-    'wintersport': 'winter Sports',
-    'paardensport': 'equestrian',
-    'evenementen': 'special event',
-    'sportmagazine': 'sports magazine',
+    'talk show': 'talk show',
+
+    # 04
+    'sport': 'sports',
+    'evenementen': 'special events (olympic games, world cup, etc.)',
+    'sportmagazine': 'sports magazines',
     'voetbal': 'football/soccer',
     'tennis/squash': 'tennis/squash',
-    'teamsporten': 'Team sports',
+    'teamsporten': 'team sports (excluding football)',
     'atletiek': 'athletics',
     'motorsport': 'motor sport',
     'extreme': 'motor sport',
     'watersport': 'water sport',
-    'kids/jeugd': 'children\'s/youth program (general)',
-    'kids 0 - 6': 'pre-school children\'s program',
-    'jeugd 6 - 14': 'entertainment (6-14 year old)',
-    'jeugd 10 - 16': 'entertainment (10-16 year old)',
-    'poppenspel': 'cartoon/puppets',
+    'wintersport': 'winter sports',
+    'paardensport': 'equestrian',
+    'gevechtssport': 'martial sports',
+
+    # 05
+    'kids/jeugd': 'children\'s / youth programs',
+    'kids 0 - 6': 'pre-school children\'s programs',
+    'kids, 0-6': 'pre-school children\'s programs',
+    'jeugd 6 - 14': 'entertainment programs for 6 to 14',
+    'jeugd 10 - 16': 'entertainment programs for 10 to 16',
     'educatie': 'information/educational/school program',
+    'poppenspel': 'cartoon/puppets',
+
+    # 06
     'muziek': 'music/ballet/dance',
-    'ballet': 'ballet',
     'easy listening': 'music/ballet/dance',
-    'musical': 'musical/opera',
     'rock/pop': 'rock/pop',
     'klassiek': 'serious music/classical music',
     'volksmuziek': 'folk/traditional music',
     'jazz': 'jazz',
     'musical': 'musical/opera',
-    'lifestyle': 'arts/culture (without music, general)',
+    'musical/opera': 'musical/opera',
+    'ballet': 'ballet',
+
+    # 07
+    'lifestyle': 'arts/culture (without music)',
     'beeldende kunst': 'performing arts',
-    'mode': 'fashion',
-    'kunst magazine': 'arts/culture magazines',
-    'kunst/cultuur': 'arts/culture magazines',
     'religie': 'religion',
     'popart': 'popular culture/traditional arts',
     'literatuur': 'literature',
     'speelfilm': 'film/cinema',
+    'film/cinema': 'film/cinema',
     'shorts': 'experimental film/video',
     'special': 'broadcasting/press',
-    'maatschappelijk': 'social/political issues/economics (general)',
+    'kunst magazine': 'arts magazines/culture magazines',
+    'kunst/cultuur': 'arts magazines/culture magazines',
+    'mode': 'fashion',
+
+    # 08
+    'maatschappelijk': 'social/political issues/economics',
     'actualiteiten': 'magazines/reports/documentary',
     'economie': 'economics/social advisory',
     'beroemdheden': 'remarkable people',
-    'educatie': 'education/science/factual topics (general)',
+
+    # 09
     'natuur': 'nature/animals/environment',
     'technologie': 'technology/natural sciences',
     'geneeskunde': 'medicine/physiology/psychology',
@@ -82,15 +111,17 @@ class XMLTVDocument(object):
     'sociologie': 'social/spiritual sciences',
     'educatie divers': 'further education',
     'talen': 'languages',
-    'vrije tijd': 'leisure hobbies (general)',
-    'reizen': 'tourism/travel',
+
+    # 10
+    'vrije tijd': 'leisure hobbies',
+    'reizen': 'tourism / travel',
     'klussen': 'handicraft',
     'auto en motor': 'motoring',
-    'gezondheid': 'fitness & health',
+    'gezondheid': 'fitness and health',
     'koken': 'cooking',
-    'shoppen': 'advertisement/shopping',
+    'shoppen': 'advertisement / shopping',
     'tuinieren': 'gardening'
-    }
+  }
 
   def __init__(self):
     impl = xml.dom.minidom.getDOMImplementation()
@@ -100,7 +131,8 @@ class XMLTVDocument(object):
     self.document.documentElement.setAttribute('source-info-name', 'UPC Horizon API')
     self.document.documentElement.setAttribute('generator-info-name', 'HorEPG v1.0')
     self.document.documentElement.setAttribute('generator-info-url', 'beralt.nl/horepg')
-  def addChannel(self, channel_id, display_name, icon = None):
+
+  def addChannel(self, channel_id, display_name, icon=None):
     element = self.document.createElement('channel')
     element.setAttribute('id', channel_id)
 
@@ -123,14 +155,15 @@ class XMLTVDocument(object):
         dn_element.appendChild(dn_text)
         element.appendChild(dn_element)
 
-    if(icon):
+    if (icon):
       lu_element = self.document.createElement('icon')
       lu_element.setAttribute('src', icon)
       element.appendChild(lu_element)
 
     self.document.documentElement.appendChild(element)
 
-  def addProgramme(self, channel_id, title, start, end, episode = None, episode_title = None, description = None, categories = None):
+  def addProgramme(self, channel_id, title, start, end, episode=None, episode_title=None, description=None,
+                   categories=None):
     element = self.document.createElement('programme')
     element.setAttribute('start', XMLTVDocument.convert_time(int(start)))
     element.setAttribute('stop', XMLTVDocument.convert_time(int(end)))
@@ -140,24 +173,31 @@ class XMLTVDocument(object):
     if episode:
       self.quick_tag(element, 'episode-num', episode, {'system': 'onscreen'})
     if description:
-      self.quick_tag(element, 'desc', description) 
+      self.quick_tag(element, 'desc', description)
     if episode_title:
       self.quick_tag(element, 'sub-title', episode_title)
     # categories
     if categories:
       for cat in categories:
-        if '/' not in cat:
-          cat_title = XMLTVDocument.map_category(cat.lower())
-          if cat_title:
-            self.quick_tag(element, 'category', cat_title)
-          else:
-            self.quick_tag(element, 'category', cat)
+        cat_title = XMLTVDocument.map_category(cat.lower())
+        if cat_title:
+          self.quick_tag(element, 'category', cat_title)
+        elif '/' not in cat:
+          warning(
+            "CHANNEL '{}', PROGRAM '{}': No XMLTV translation for category '{}'".format(channel_id, title,
+                                                                                        cat))
+          self.quick_tag(element, 'category', cat.lower())
+        else:
+          debug(
+            "CHANNEL '{}', PROGRAM '{}': Skipping category '{}' due to '/'".format(channel_id, title, cat))
     self.document.documentElement.appendChild(element)
+
   def map_category(cat):
     if cat in XMLTVDocument.category_map:
       return XMLTVDocument.category_map[cat]
     return False
-  def quick_tag(self, parent, tag, content, attributes = False):
+
+  def quick_tag(self, parent, tag, content, attributes=False):
     element = self.document.createElement(tag)
     text = self.document.createTextNode(content)
     element.appendChild(text)
@@ -165,5 +205,6 @@ class XMLTVDocument(object):
       for k, v in attributes.items():
         element.setAttribute(k, v)
     parent.appendChild(element)
+
   def convert_time(t):
     return time.strftime('%Y%m%d%H%M%S', time.gmtime(t))


### PR DESCRIPTION
The main purpose of this pull request is to add missing EPG category mappings and make the mapping result match what TVHeadend expects (by checking the expected strings in the TVHeadend source code).

The request also adds a simple fix for HTTP digest authentication with TVHeadend. I confirmed it works with version 4.2.

To ease in debugging I added an output to file option to `horepgd.py` so it is possible to review the results of a normal run and not make changes to TV Headend.