### PR TITLE
Fix bug with 8 hour EPG limit and final changes to category mapping

### DIFF
--- a/horepg/xmltvdoc.py
+++ b/horepg/xmltvdoc.py
@@ -15,6 +15,9 @@ class XMLTVDocument(object):
   # this renames some of the channels
   add_display_name = {}
   category_map = {
+    # 00
+    'onbepaald': '',
+
     # 01
     'tv drama': 'movie/drama',
     'actie': 'movie/drama',
@@ -29,6 +32,7 @@ class XMLTVDocument(object):
     'komedie': 'comedy',
     'melodrama': 'soap/melodrama/folkloric',
     'romantiek': 'romance',
+    'romantisch': 'romance',
     'drama': 'serious/classical/religious/historical movie/drama',
     'erotiek': 'adult movie/drama',
 
@@ -42,7 +46,7 @@ class XMLTVDocument(object):
     'discussie': 'discussion/interview/debate',
 
     # 03
-    'show': 'game show/quiz/contest',
+    'show': 'show/game show',
     'variété': 'variety show',
     'variete': 'variety show',
     'talkshow': 'talk show',
@@ -180,12 +184,10 @@ class XMLTVDocument(object):
     if categories:
       for cat in categories:
         cat_title = XMLTVDocument.map_category(cat.lower())
-        if cat_title:
+        if cat_title is not None:
           self.quick_tag(element, 'category', cat_title)
         elif '/' not in cat:
-          warning(
-            "CHANNEL '{}', PROGRAM '{}': No XMLTV translation for category '{}'".format(channel_id, title,
-                                                                                        cat))
+          warning("CHANNEL '{}', PROGRAM '{}': No XMLTV translation for category '{}'".format(channel_id, title, cat))
           self.quick_tag(element, 'category', cat.lower())
         else:
           debug(
@@ -195,7 +197,7 @@ class XMLTVDocument(object):
   def map_category(cat):
     if cat in XMLTVDocument.category_map:
       return XMLTVDocument.category_map[cat]
-    return False
+    return None
 
   def quick_tag(self, parent, tag, content, attributes=False):
     element = self.document.createElement(tag)

--- a/horepgd.py
+++ b/horepgd.py
@@ -81,9 +81,10 @@ def run_import(wanted_channels, tvhsocket, fetch_radio=False, nr_days=5, output_
                         icon = asset['url'][:p]
                         break
                 xmltv.addChannel(channel_id, channel['title'], icon)
-                for i in range(0, nr_days):
-                    start = int((calendar.timegm(now) + 86400 * i) * 1000) # milis
-                    end = start + (86400 * 1000)
+                # Fetch in blocks of 6 hours (8 hours is the maximum block size allowed)
+                for i in range(0, nr_days*4):
+                    start = int((calendar.timegm(now) + 21600 * i) * 1000) # milis
+                    end = start + (21600 * 1000)
                     number = number + listings.obtain(xmltv, channel_id, start, end)
                 debug('Adding {:d} programmes for channel {:s}'.format(number, channel['title']))
                 if output_folder:


### PR DESCRIPTION
I noticed that for some channels there was no longer full EPG data (notably, Veronica/Disney XD).
On investigation I found that the EPG service now limits replies to 8 hour windows. Thus we were missing about 16 hours a day of EPG data.

To fix this I made the download loop do blocks of 6 hours so we don't miss programs that fall just on the edge of that window (and because I like 4 better as a multiplier then 3 :) ).

Also included is some last cleanup of the category mapping (for now, Ziggo keeps inventing new categories it seems :( ).