### PR TITLE
Fix HorizonRequest ignoring a 404 status code

### DIFF
--- a/horepg/horizon.py
+++ b/horepg/horizon.py
@@ -33,9 +33,9 @@ class HorizonRequest(object):
             return self.request(method, path, retry=True)
         if response.status == 200:
             return response
-        elif response.status == 403:
+        elif response.status in (403, 404):
             # switch hosts
-            debug('Switching hosts')
+            debug('Switching hosts due to status code {:0} from host {:s}'.format(response.status, HorizonRequest.hosts[self.current]))
             if self.current == 0:
                 self.current = 1
             else:


### PR DESCRIPTION
On return of a 404 status code, the HorizonRequest class ignores the 404 status code and takes no action. This causes horepg to crash. To fix this, status code 404 is to be treated the same as code 403; the EPG is being hosted on the other server.

Fixes #27